### PR TITLE
Fix ctypes SDK prototypes

### DIFF
--- a/thermal_analyzer_python_ver.py
+++ b/thermal_analyzer_python_ver.py
@@ -270,7 +270,7 @@ class ThermalCameraSDK:
         self.thermal_sdk.CloseConnect.restype = SHORT
 
         self.thermal_sdk.GetIRImages.argtypes = [
-            UINT,
+            HANDLE,
             ctypes.POINTER(HANDLE),
             ctypes.POINTER(IRF_IR_CAM_DATA_T),
         ]
@@ -278,7 +278,7 @@ class ThermalCameraSDK:
 
         self.thermal_sdk.GetImageCG.argtypes = [
             ctypes.POINTER(BYTE),
-            UINT,
+            HANDLE,
             LONG,
             ctypes.POINTER(FLOAT),
             ctypes.POINTER(FLOAT),
@@ -287,7 +287,7 @@ class ThermalCameraSDK:
         self.thermal_sdk.GetImageCG.restype = SHORT
 
         self.thermal_sdk.SendCameraMessage.argtypes = [
-            UINT,
+            HANDLE,
             ctypes.POINTER(HANDLE),
             INT,
             WORD,
@@ -296,7 +296,7 @@ class ThermalCameraSDK:
         self.thermal_sdk.SendCameraMessage.restype = SHORT
 
         self.thermal_sdk.SendMessageToCamera.argtypes = [
-            UINT,
+            HANDLE,
             ctypes.POINTER(HANDLE),
             INT,
             WORD,
@@ -308,7 +308,7 @@ class ThermalCameraSDK:
         self.thermal_sdk.SendMessageToCamera.restype = SHORT
 
         self.thermal_sdk.GetPointTempCG.argtypes = [
-            UINT,
+            HANDLE,
             IRF_IMAGE_INFO_T,
             IRF_TEMP_CORRECTION_PAR_T,
             POINT,
@@ -329,7 +329,7 @@ class ThermalCameraSDK:
     def get_ir_images(self, h_sdk, keep_alive_id_ptr, ir_data_ptr):
         if not self.thermal_sdk:
             return -1
-        return self.thermal_sdk.GetIRImages(h_sdk.value, keep_alive_id_ptr, ir_data_ptr)
+        return self.thermal_sdk.GetIRImages(h_sdk, keep_alive_id_ptr, ir_data_ptr)
 
     def get_image_lut(self, p_palette_lut, lp, is_invert):
         if not self.thermal_sdk:
@@ -339,22 +339,22 @@ class ThermalCameraSDK:
     def get_image_cg(self, p_ir_tmp_buf, h_sdk, size, level_ptr, span_ptr, agc_ctrl_ptr):
         if not self.thermal_sdk:
             return -1
-        return self.thermal_sdk.GetImageCG(p_ir_tmp_buf, h_sdk.value, size, level_ptr, span_ptr, agc_ctrl_ptr)
+        return self.thermal_sdk.GetImageCG(p_ir_tmp_buf, h_sdk, size, level_ptr, span_ptr, agc_ctrl_ptr)
 
     def send_camera_message(self, h_sdk, keep_alive_id_ptr, msg_type, pmsg_type, rcode):
         if not self.thermal_sdk:
             return -1
-        return self.thermal_sdk.SendCameraMessage(h_sdk.value, keep_alive_id_ptr, msg_type, pmsg_type, rcode)
+        return self.thermal_sdk.SendCameraMessage(h_sdk, keep_alive_id_ptr, msg_type, pmsg_type, rcode)
 
     def send_message_to_camera(self, h_sdk, keep_alive_id_ptr, msg_type, pmsg_type, rcode, rcode2, rcode3, rcode4):
         if not self.thermal_sdk:
             return -1
-        return self.thermal_sdk.SendMessageToCamera(h_sdk.value, keep_alive_id_ptr, msg_type, pmsg_type, rcode, rcode2, rcode3, rcode4)
+        return self.thermal_sdk.SendMessageToCamera(h_sdk, keep_alive_id_ptr, msg_type, pmsg_type, rcode, rcode2, rcode3, rcode4)
 
     def get_point_temp_cg(self, h_sdk, ir_info, temp_corr_params, point):
         if not self.thermal_sdk:
             return -1
-        return self.thermal_sdk.GetPointTempCG(h_sdk.value, ir_info, temp_corr_params, point)
+        return self.thermal_sdk.GetPointTempCG(h_sdk, ir_info, temp_corr_params, point)
 
     def is_dll_loaded(self):
         return self.thermal_sdk is not None


### PR DESCRIPTION
## Summary
- ensure ctypes prototypes use HANDLE type for SDK handles
- pass handles directly when calling SDK functions

## Testing
- `python3 -m py_compile thermal_analyzer_python_ver.py`


------
https://chatgpt.com/codex/tasks/task_e_686c7ef047f8832fb571c70b4cf84e6c